### PR TITLE
build: fix building with poetry version 1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,9 @@ pandas = "^1.3.3"
 script = "build.py"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = [
+    "poetry-core>=1.1.0",
+    "setuptools>=65.4.1",
+    "pybind11>=2.8.0"
+]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
poetry 1.2 creates separate environment for building, this requires proper specification of packages necessary for building